### PR TITLE
netbios name can only have 15 chars

### DIFF
--- a/templates/etc/samba/smb.conf.j2
+++ b/templates/etc/samba/smb.conf.j2
@@ -3,7 +3,7 @@
 [global]
         workgroup = {{ samba_ad_info.netbios_domain_name|upper }}
         realm = {{ samba_ad_info.kerberos_realm|upper }}
-        netbios name = {{ ansible_hostname|upper }}
+        netbios name = {{ ansible_hostname|upper|truncate(15, True, '') }}
         server role = {{ samba_server_role }}
         dns forwarder = {{ samba_ad_info.dns_forwarder }}
         server services = rpc, nbt, wrepl, ldap, cldap, kdc, drepl, winbind, ntp_signd, kcc, dnsupdate, dns, smb


### PR DESCRIPTION
hi,
this allows to use the role in setups which use longer hostnames.

if you don't truncate the name, you get this error:
ERROR(<class 'samba.provision.InvalidNetbiosName'>): uncaught exception - The name ''UBUNTU-14-04-6449'' is not a valid NetBIOS name
File "/usr/lib/python2.7/dist-packages/samba/netcmd/init.py", line 175, in _run
return self.run(*args, **kwargs)
File "/usr/lib/python2.7/dist-packages/samba/netcmd/domain.py", line 442, in run
nosync=ldap_backend_nosync, ldap_dryrun_mode=ldap_dryrun_mode)
File "/usr/lib/python2.7/dist-packages/samba/provision/init.py", line 2025, in provision
sitename=sitename, rootdn=rootdn, domain_names_forced=(samdb_fill == FILL_DRS))
File "/usr/lib/python2.7/dist-packages/samba/provision/init.py", line 587, in guess_names
raise InvalidNetbiosName(netbiosname)

-> this is the same as PR 1 which was closed by accident / https://github.com/mrlesmithjr/ansible-samba/pull/1