### PR TITLE
Add support to compile/install/upgrade samba from source (Fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ samba_users: []
   #   # Define samba user password
   #   smbpasswd: P@55w0rd
 samba_workgroup: "{{ samba_netbios_domain_name[0]|upper }}"
+
+# Compile and install Samba from source
+samba_source_install: false
+# Which Samba version to install
+samba_source_version: 4.8.4
+# Upgrade installation from source
+samba_source_upgrade: false
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,3 +110,9 @@ samba_use_printers: False
 samba_printer_type: cups
 samba_cups_server: 'localhost:631'
 
+# Compile and install Samba from source
+samba_source_install: false
+# Which Samba version to install
+samba_source_version: 4.8.4
+# Upgrade installation from source
+samba_source_upgrade: false

--- a/files/etc/systemd/system/samba-ad-dc.service
+++ b/files/etc/systemd/system/samba-ad-dc.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Samba Active Directory Domain Controller
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+ExecStart=/usr/local/sbin/samba -D
+PIDFile=/run/samba/samba.pid
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/files/etc/tmpfiles.d/samba.conf
+++ b/files/etc/tmpfiles.d/samba.conf
@@ -1,0 +1,2 @@
+#Type Path           Mode UID  GID  Age Argument
+d    /run/samba      0755 root root -   -

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,13 +4,22 @@
   service:
     name: "nmbd"
     state: restarted
+  when: >
+        ansible_os_family == "Debian" or
+        samba_server_role == "standalone server"
 
 - name: restart samba-ad-dc
   service:
     name: "samba-ad-dc"
     state: restarted
+  when: >
+        ansible_os_family == "Debian" or
+        samba_server_role == "active directory domain controller"
     
 - name: restart smbd
   service:
     name: "smbd"
     state: restarted
+  when: >
+        ansible_os_family == "Debian" or
+        samba_server_role == "standalone server"

--- a/tasks/create_domain.yml
+++ b/tasks/create_domain.yml
@@ -18,7 +18,7 @@
   register: samba_ad_created_check
 
 - name: create_domain | configuring Active Directory
-  shell: "samba-tool domain provision --realm={{ samba_ad_info['kerberos_realm']|upper }} --domain={{ samba_ad_info['netbios_domain_name']|upper }} --adminpass='{{ samba_ad_info['adminpass'] }}' --server-role='domain controller' --use-rfc2307"
+  shell: "{{ samba_tool }} domain provision --realm={{ samba_ad_info['kerberos_realm']|upper }} --domain={{ samba_ad_info['netbios_domain_name']|upper }} --adminpass='{{ samba_ad_info['adminpass'] }}' --server-role='domain controller' --use-rfc2307"
   become: true
   register: samba_ad_created
   when: >

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -6,8 +6,9 @@
   with_items:
     - samba
     - samba-common
+  when: not samba_source_install
 
-- name: debian | Installing Packages When Domain Controller
+- name: debian | Installing Kerberos Packages When Domain Controller
   apt:
     name: "{{ item }}"
     state: present
@@ -15,7 +16,21 @@
   with_items:
     - krb5-config
     - krb5-user
+  when: samba_create_domain_controller
+
+- name: debian | Installing Additional Samba Packages When Domain Controller
+  apt:
+    name: "{{ item }}"
+    state: present
+  become: true
+  with_items:
     - libnss-winbind
     - libpam-winbind
     - winbind
-  when: samba_create_domain_controller
+  when: samba_create_domain_controller and not samba_source_install
+
+- name: debian | Installing Samba Build-Depends When Building From Source
+  apt:
+    name: samba
+    state: build-dep
+  when: samba_source_install

--- a/tasks/domain_groups.yml
+++ b/tasks/domain_groups.yml
@@ -1,25 +1,25 @@
 ---
 - name: domain_groups | Generate Domain Group List
-  command: samba-tool group list
+  command: "{{ samba_tool }} group list"
   register: _samba_domain_groups
   become: true
   changed_when: false
 
 - name: domain_groups | Creating Domain Groups
-  command: samba-tool group add {{ item['name'] }}
+  command: "{{ samba_tool }} group add {{ item['name'] }}"
   become: true
   with_items: "{{ samba_domain_groups }}"
   when: item['name'] not in _samba_domain_groups['stdout']
 
 - name: domain_groups | Capturing Domain Group Members
-  command: samba-tool group listmembers "{{ item['name'] }}"
+  command: "{{ samba_tool }} group listmembers \"{{ item['name'] }}\""
   become: true
   register: _samba_domain_group_members
   changed_when: false
   with_items: "{{ samba_domain_groups }}"
 
 - name: domain_groups | Managing Domain Group Members
-  command: samba-tool group addmembers {{ item.0.item.name }} {{ item.1 }}
+  command: "{{ samba_tool }} group addmembers {{ item.0.item.name }} {{ item.1 }}"
   become: true
   with_subelements:
     - "{{ _samba_domain_group_members['results'] }}"

--- a/tasks/domain_users.yml
+++ b/tasks/domain_users.yml
@@ -1,10 +1,10 @@
 ---
 - name: domain_users | generate list of users
-  command: "samba-tool user list"
+  command: "{{ samba_tool }} user list"
   register: domain_users
 
 - name: domain_users | creating domain users
-  command: "samba-tool user add {{ item['name'] }} '{{ item['password'] }}'"
+  command: "{{ samba_tool }} user add {{ item['name'] }} '{{ item['password'] }}'"
 #  ignore_errors: true   #defined for now to get around potential bug in failed_when conditionals
   with_items: '{{ samba_domain_users }}'
   when: item['name'] not in domain_users['stdout']

--- a/tasks/join_domain.yml
+++ b/tasks/join_domain.yml
@@ -5,7 +5,7 @@
   register: samba_ad_join_check
 
 - name: join_domain | Joining Domain
-  shell: samba-tool domain join {{ samba_ad_info['ad_dns_domain_name'] }} DC --username="{{ samba_ad_info['netbios_domain_name']|upper }}\administrator" --password="{{ samba_ad_info['adminpass'] }}"
+  shell: "{{ samba_tool }} domain join {{ samba_ad_info['ad_dns_domain_name'] }} DC --username=\"{{ samba_ad_info['netbios_domain_name']|upper }}\administrator\" --password=\"{{ samba_ad_info['adminpass'] }}\""
   become: true
   register: _samba_domain_joined
   when: not samba_ad_join_check['stat']['exists']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,12 @@
 - include: debian.yml
   when: ansible_os_family == "Debian"
 
+- include: redhat.yml
+  when: ansible_os_family == "RedHat"
+
+- include: source_install.yml
+  when: samba_source_install
+
 - include: samba_groups.yml
   when: samba_groups is defined
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,22 @@
+---
+
+- name: redhat | Installing Samba Build-Depends When Building From Source
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "@Development Tools"
+    - iniparser
+    - libldb
+    - libtalloc
+    - libtdb
+    - libtevent
+    - python-devel
+    - gnutls-devel
+    - libacl-devel
+    - openldap-devel
+    - pam-devel
+    - readline-devel
+    - krb5-devel
+    - cups-devel
+  when: samba_source_install

--- a/tasks/samba_users.yml
+++ b/tasks/samba_users.yml
@@ -9,5 +9,5 @@
     - groups
 
 - name: samba_users | creating samba user passwords
-  shell: "(echo {{ item['smbpasswd'] }}; echo {{ item['smbpasswd'] }}) | smbpasswd -s -a {{ item['name'] }}"
+  shell: "(echo {{ item['smbpasswd'] }}; echo {{ item['smbpasswd'] }}) | {{ smbpasswd }} -s -a {{ item['name'] }}"
   with_items: '{{ samba_users }}'

--- a/tasks/source_install.yml
+++ b/tasks/source_install.yml
@@ -1,0 +1,112 @@
+---
+
+- name: source_install | create samba source directory
+  file:
+    name: "/usr/local/src/samba"
+    state: directory
+
+- name: source_install | check if samba is already installed from source
+  stat:
+    path: /usr/local/sbin/samba
+  register: __samba_source_installed
+
+- name: source_install | fetch and unpack samba source tarball
+  unarchive:
+    src: "https://download.samba.org/pub/samba/samba-{{ samba_source_version }}.tar.gz"
+    dest: "/usr/local/src/samba/"
+    remote_src: true
+    creates: "/usr/local/src/samba/samba-{{ samba_source_version }}"
+  register: __samba_unarchive
+  when: samba_source_upgrade or not __samba_source_installed.stat.exists
+
+- name: source_install | run samba configure script
+  command: >
+    ./configure --prefix=/usr/local
+      --localstatedir=/var/local \
+      --with-configdir=/etc/samba \
+      --libdir=/usr/local/lib64 \
+      --with-modulesdir=/usr/local/lib64/samba \
+      --with-pammodulesdir=/lib64/security \
+      --with-lockdir=/var/local/lib/samba \
+      --with-logfilebase=/var/log/samba \
+      --with-piddir=/run/samba \
+      --with-privatedir=/etc/samba \
+      --enable-cups \
+      --with-acl-support \
+      --with-ads \
+      --with-automount \
+      --enable-fhs \
+      --with-pam \
+      --with-quotas \
+      --with-shared-modules=idmap_rid,idmap_ad,idmap_hash,idmap_adex \
+      --with-syslog \
+      --with-utmp \
+      --with-dnsupdate 
+  args:
+    chdir: "/usr/local/src/samba/samba-{{ samba_source_version }}"
+    creates: "/usr/local/src/samba/samba-{{ samba_source_version }}/bin/config.log"
+  when: samba_source_upgrade or not __samba_source_installed.stat.exists
+
+- name: source_install | run samba Makefile default target (build)
+  make:
+    chdir: "/usr/local/src/samba/samba-{{ samba_source_version }}"
+  when: samba_source_upgrade or not __samba_source_installed.stat.exists
+
+- name: source_install | run samba Makefile install target (install)
+  make:
+    chdir: "/usr/local/src/samba/samba-{{ samba_source_version }}"
+    target: install
+  when: samba_source_upgrade or not __samba_source_installed.stat.exists
+
+- name: source_install | install samba tmpfile file
+  copy:
+    src: "etc/tmpfiles.d/samba.conf"
+    dest: "/etc/tmpfiles.d/samba.conf"
+    owner: root
+    group: root
+    mode: 0644
+
+- name: source_install | install samba-ad-dc systemd service file
+  copy:
+    src: "etc/systemd/system/samba-ad-dc.service"
+    dest: "/etc/systemd/system/samba-ad-dc.service"
+    owner: root
+    group: root
+    mode: 0644
+  notify: reload systemd
+
+- name: source_install | enable samba-ad-dc systemd service
+  systemd:
+    name: samba-ad-dc
+    enabled: yes
+    daemon_reload: yes
+
+- name: source_install | install remaining samba systemd service files
+  copy:
+    src: "/usr/local/src/samba/samba-{{ samba_source_version }}/bin/default/packaging/systemd/{{ item }}.service"
+    dest: "/etc/systemd/system/{{ item }}.service"
+    remote_src: True
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - nmb
+    - smb
+  notify: reload systemd
+  when: samba_server_role == "standalone server"
+
+- name: source_install | enable remaining samba systemd services
+  systemd:
+    name: "{{ item }}"
+    enabled: yes
+    daemon_reload: yes
+  with_items:
+    - nmb
+    - smb
+  when: samba_server_role == "standalone server"
+
+#- name: remove samba build files
+#  file:
+#    path: "/usr/local/src/samba/samba-{{ samba_source_version }}"
+#    state: absent
+#  when: samba_source_upgrade or not __samba_source_installed.stat.exists

--- a/templates/etc/samba/smb.conf.j2
+++ b/templates/etc/samba/smb.conf.j2
@@ -18,11 +18,11 @@
 {% endif %}
 
 [netlogon]
-	path = /var/lib/samba/sysvol/{{ samba_ad_info.kerberos_realm|lower }}/scripts
+	path = /var{{ '/local' if samba_source_install }}/lib/samba/sysvol/{{ samba_ad_info.kerberos_realm|lower }}/scripts
 	read only = No
 
 [sysvol]
-	path = /var/lib/samba/sysvol
+	path = /var{{ '/local' if samba_source_install }}/lib/samba/sysvol
 	read only = No
 {% elif (samba_create_domain_controller is defined and not samba_create_domain_controller) or samba_create_domain_controller is not defined %}
 #======================= Global Settings =======================
@@ -47,7 +47,7 @@
    log file = /var/log/samba/log.%m
    max log size = 1000
    syslog = 0
-   panic action = /usr/share/samba/panic-action %d
+   panic action = /usr{{ '/local' if samba_source_install }}/share/samba/panic-action %d
 
 
 ####### Authentication #######

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,7 @@
 ---
 # vars file for ansible-samba
+
+# On RHEL/CentOS, `/usr/local/bin` is not part of sudo $PATH, thus we give
+# the full path to binaries from there when installing from source.
+samba_tool: "{{ samba_source_install|ternary('/usr/local/bin/', '') }}samba-tool"
+smbpasswd: "{{ samba_source_install|ternary('/usr/local/bin/', '') }}smbpasswd"


### PR DESCRIPTION
* Since Samba packages on RHEL/CentOS 7 don't ship `samba-tool` and
  other AD domain controller specific things, the best option there
  is to compile Samba from source.
* Besides installing samba from source, systemd service and tmpfile
  files are installed for managing the Samba services.
* Some additional adjustments were necessary:
  + The handlers to restart services have conditions now: when installed
    from source, nmbd+smbd are only restarted when running with server
    role `standalone server`. For server role `active directory domain
    controller`, the samba-ad-dc service will take care of those
    services internally (at least when installed from source).
  + Tasks were added for both Debian and RedHat to install build
    dependencies for samba.
  + For some reason, `/usr/local/bin' is not in sudo `$PATH` on
    RHEL/CentOS 7. Thus, when installed from source, full paths to
    binaries in `/usr/local/bin` are given.
  + In the `smb.conf` template, paths are adjusted when installed from
    source.